### PR TITLE
fix: consolidate CD/Release workflows to all-in-one Docker image and add explicit permissions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,6 +22,14 @@ env:
   DOCKER_REGISTRY: ghcr.io
   DOCKER_REPOSITORY: partshub
 
+permissions:
+  contents: write      # For GitHub Pages deployment and repo checkout
+  packages: write      # For pushing Docker images to GHCR
+  issues: write        # For creating/commenting on deployment tracking issues
+  checks: read         # For checking CI workflow status
+  actions: write       # For GitHub Actions cache (Docker layer caching)
+  statuses: read       # For workflow status checks
+
 jobs:
   check_ci_status:
     name: "Check CI Status"
@@ -43,8 +51,8 @@ jobs:
         id: check
         run: echo "ci_passed=true" >> $GITHUB_OUTPUT
 
-  deploy_backend:
-    name: "Deploy Backend"
+  deploy_application:
+    name: "Deploy Application (All-in-One)"
     runs-on: ubuntu-latest
     needs: [check_ci_status]
     if: ${{ always() && (needs.check_ci_status.outputs.ci_passed == 'true' || inputs.skip_tests) }}
@@ -74,104 +82,52 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "tag=${{ env.DOCKER_REGISTRY }}/${{ github.repository }}:$VERSION" >> $GITHUB_OUTPUT
 
-      - name: Build and push backend image
+      - name: Build and push all-in-one image
         uses: docker/build-push-action@v5
         with:
           context: .
           file: Dockerfile
-          target: backend
+          target: development
           push: true
           tags: |
-            ${{ steps.version.outputs.tag }}-backend
-            ${{ env.DOCKER_REGISTRY }}/${{ github.repository }}:latest-backend
+            ${{ steps.version.outputs.tag }}
+            ${{ env.DOCKER_REGISTRY }}/${{ github.repository }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Deploy backend to production
+      - name: Deploy application to production
         id: deploy
         run: |
-          echo "Deploying backend image: ${{ steps.version.outputs.tag }}-backend"
+          echo "Deploying all-in-one image: ${{ steps.version.outputs.tag }}"
           # Note: This is a placeholder for actual deployment logic
           # In a real scenario, this would use kubectl, docker-compose, or deployment service
           echo "status=success" >> $GITHUB_OUTPUT
-          echo "url=https://api.partshub.production" >> $GITHUB_OUTPUT
+          echo "url=https://partshub.production" >> $GITHUB_OUTPUT
 
-      - name: Health check
+      - name: Health check - Backend
         run: |
-          echo "Performing health check..."
+          echo "Performing backend health check..."
           # Note: Replace with actual health check endpoint
-          # curl -f https://api.partshub.production/health || exit 1
-          sleep 5
-          echo "Health check passed"
+          # curl -f https://partshub.production/health || exit 1
+          sleep 3
+          echo "Backend health check passed"
+
+      - name: Health check - Frontend
+        run: |
+          echo "Verifying frontend accessibility..."
+          # Note: Replace with actual frontend URL
+          # curl -f https://partshub.production || exit 1
+          sleep 3
+          echo "Frontend accessible"
 
       - name: Upload deployment logs
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: backend-deployment-logs
+          name: deployment-logs
           path: |
             /tmp/deployment-*.log
           retention-days: 90
-
-  deploy_frontend:
-    name: "Deploy Frontend"
-    runs-on: ubuntu-latest
-    needs: [deploy_backend]
-    if: ${{ always() && needs.deploy_backend.outputs.deployment_status == 'success' }}
-    environment: production
-    outputs:
-      deployment_status: ${{ steps.deploy.outputs.status }}
-      deployment_url: ${{ steps.deploy.outputs.url }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.DOCKER_REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract version from pyproject.toml
-        id: version
-        run: |
-          VERSION=$(grep '^version =' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "tag=${{ env.DOCKER_REGISTRY }}/${{ github.repository }}:$VERSION" >> $GITHUB_OUTPUT
-
-      - name: Build and push frontend image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: Dockerfile
-          target: frontend
-          push: true
-          tags: |
-            ${{ steps.version.outputs.tag }}-frontend
-            ${{ env.DOCKER_REGISTRY }}/${{ github.repository }}:latest-frontend
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Deploy frontend to production
-        id: deploy
-        run: |
-          echo "Deploying frontend image: ${{ steps.version.outputs.tag }}-frontend"
-          # Note: This is a placeholder for actual deployment logic
-          echo "status=success" >> $GITHUB_OUTPUT
-          echo "url=https://partshub.production" >> $GITHUB_OUTPUT
-
-      - name: Verify frontend accessibility
-        run: |
-          echo "Verifying frontend accessibility..."
-          # Note: Replace with actual frontend URL
-          # curl -f https://partshub.production || exit 1
-          sleep 5
-          echo "Frontend accessible"
 
   build_and_deploy_docs:
     name: "Build and Deploy Documentation"
@@ -215,7 +171,7 @@ jobs:
   notify_deployment:
     name: "Notify Deployment Results"
     runs-on: ubuntu-latest
-    needs: [deploy_backend, deploy_frontend, build_and_deploy_docs]
+    needs: [deploy_application, build_and_deploy_docs]
     if: always()
 
     steps:
@@ -225,14 +181,14 @@ jobs:
       - name: Prepare deployment summary
         id: summary
         run: |
-          BACKEND_STATUS="${{ needs.deploy_backend.outputs.deployment_status || 'skipped' }}"
-          FRONTEND_STATUS="${{ needs.deploy_frontend.outputs.deployment_status || 'skipped' }}"
+          APP_STATUS="${{ needs.deploy_application.outputs.deployment_status || 'skipped' }}"
+          APP_URL="${{ needs.deploy_application.outputs.deployment_url || 'N/A' }}"
           DOCS_URL="${{ needs.build_and_deploy_docs.outputs.docs_url || 'N/A' }}"
 
           SUMMARY="🚀 **Deployment Summary**
 
-          - **Backend**: $BACKEND_STATUS
-          - **Frontend**: $FRONTEND_STATUS
+          - **Application**: $APP_STATUS
+          - **Application URL**: $APP_URL
           - **Documentation**: [Available]($DOCS_URL)
 
           **Commit**: ${{ github.sha }}
@@ -306,8 +262,8 @@ jobs:
   rollback_on_failure:
     name: "Automatic Rollback"
     runs-on: ubuntu-latest
-    needs: [deploy_backend, deploy_frontend]
-    if: ${{ failure() && (needs.deploy_backend.result == 'failure' || needs.deploy_frontend.result == 'failure') }}
+    needs: [deploy_application]
+    if: ${{ failure() && needs.deploy_application.result == 'failure' }}
 
     steps:
       - name: Checkout code
@@ -326,7 +282,7 @@ jobs:
           script: |
             const rollbackSummary = `🔄 **Automatic Rollback Performed**
 
-            **Reason**: Deployment failure
+            **Reason**: Application deployment failure
             **Commit**: ${{ github.sha }}
             **Rollback Time**: ${new Date().toISOString()}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ name: "Continuous Integration"
 env:
   UV_CACHE_DIR: /tmp/.uv-cache
 
+permissions:
+  contents: read       # For repository checkout
+  actions: write       # For caching dependencies
+
 jobs:
   backend_tests:
     name: "Backend Tests"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,12 @@ env:
   DOCKER_REGISTRY: ghcr.io
   DOCKER_REPOSITORY: partshub
 
+permissions:
+  contents: write      # For creating releases, updating releases, and GitHub Pages deployment
+  packages: write      # For pushing Docker images to GHCR
+  issues: write        # For creating release notification issues
+  actions: write       # For GitHub Actions cache (Docker layer caching)
+
 jobs:
   validate_release:
     name: "Validate Release Prerequisites"
@@ -131,8 +137,8 @@ jobs:
           path: release-artifacts/
           retention-days: 90
 
-  build_docker_images:
-    name: "Build and Publish Docker Images"
+  build_docker_image:
+    name: "Build and Publish Docker Image"
     runs-on: ubuntu-latest
     needs: [validate_release]
     if: ${{ needs.validate_release.outputs.version_valid == 'true' }}
@@ -151,40 +157,26 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push backend image
+      - name: Build and push all-in-one image
         uses: docker/build-push-action@v5
         with:
           context: .
           file: Dockerfile
-          target: backend
+          target: development
           push: true
           tags: |
-            ${{ env.DOCKER_REGISTRY }}/${{ github.repository }}-backend:latest
-            ${{ env.DOCKER_REGISTRY }}/${{ github.repository }}-backend:${{ needs.validate_release.outputs.version }}
-            ${{ env.DOCKER_REGISTRY }}/${{ github.repository }}-backend:${{ github.sha }}
+            ${{ env.DOCKER_REGISTRY }}/${{ github.repository }}:latest
+            ${{ env.DOCKER_REGISTRY }}/${{ github.repository }}:${{ needs.validate_release.outputs.version }}
+            ${{ env.DOCKER_REGISTRY }}/${{ github.repository }}:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Build and push frontend image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: Dockerfile
-          target: frontend
-          push: true
-          tags: |
-            ${{ env.DOCKER_REGISTRY }}/${{ github.repository }}-frontend:latest
-            ${{ env.DOCKER_REGISTRY }}/${{ github.repository }}-frontend:${{ needs.validate_release.outputs.version }}
-            ${{ env.DOCKER_REGISTRY }}/${{ github.repository }}-frontend:${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Run security scan on images
+      - name: Run security scan on image
         run: |
-          echo "Running security scans on Docker images..."
+          echo "Running security scan on Docker image..."
           # Note: Add actual security scanning tools like Trivy here
           # docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
-          #   aquasec/trivy image ${{ env.DOCKER_REGISTRY }}/${{ github.repository }}-backend:${{ needs.validate_release.outputs.version }}
+          #   aquasec/trivy image ${{ env.DOCKER_REGISTRY }}/${{ github.repository }}:${{ needs.validate_release.outputs.version }}
 
   generate_release_notes:
     name: "Generate Release Notes"
@@ -263,10 +255,13 @@ jobs:
           fi
           echo ""
 
-          echo "## Docker Images"
+          echo "## Docker Image"
           echo ""
-          echo "- Backend: \`ghcr.io/${{ github.repository }}-backend:$CURRENT_TAG\`"
-          echo "- Frontend: \`ghcr.io/${{ github.repository }}-frontend:$CURRENT_TAG\`"
+          echo "All-in-one image (backend + frontend):"
+          echo ""
+          echo "\`\`\`bash"
+          echo "docker pull ghcr.io/${{ github.repository }}:$CURRENT_TAG"
+          echo "\`\`\`"
           echo ""
 
           echo "## Documentation"
@@ -369,7 +364,7 @@ jobs:
   create_github_release:
     name: "Create GitHub Release"
     runs-on: ubuntu-latest
-    needs: [validate_release, build_artifacts, build_docker_images, generate_release_notes, build_versioned_docs]
+    needs: [validate_release, build_artifacts, build_docker_image, generate_release_notes, build_versioned_docs]
     if: ${{ always() && needs.validate_release.outputs.version_valid == 'true' }}
     outputs:
       release_url: ${{ steps.create_release.outputs.html_url }}
@@ -416,15 +411,22 @@ jobs:
 
             **Documentation**: ${{ needs.build_versioned_docs.outputs.docs_url }}
 
-            **Docker Images**:
-            - Backend: \`${{ env.DOCKER_REGISTRY }}/${{ github.repository }}-backend:${{ needs.validate_release.outputs.version }}\`
-            - Frontend: \`${{ env.DOCKER_REGISTRY }}/${{ github.repository }}-frontend:${{ needs.validate_release.outputs.version }}\`
+            **Docker Image**:
 
-            **Verification**:
+            All-in-one image (backend + frontend):
             \`\`\`bash
-            # Pull and run the images
-            docker pull ${{ env.DOCKER_REGISTRY }}/${{ github.repository }}-backend:${{ needs.validate_release.outputs.version }}
-            docker pull ${{ env.DOCKER_REGISTRY }}/${{ github.repository }}-frontend:${{ needs.validate_release.outputs.version }}
+            docker pull ${{ env.DOCKER_REGISTRY }}/${{ github.repository }}:${{ needs.validate_release.outputs.version }}
+            \`\`\`
+
+            **Quick Start**:
+            \`\`\`bash
+            # Run the container
+            docker run -d -p 8000:8000 -p 3000:3000 \\
+              ${{ env.DOCKER_REGISTRY }}/${{ github.repository }}:${{ needs.validate_release.outputs.version }}
+
+            # Access the application
+            # Backend API: http://localhost:8000
+            # Frontend: http://localhost:3000
             \`\`\``;
 
             await github.rest.repos.updateRelease({
@@ -451,9 +453,10 @@ jobs:
             **Release URL**: ${{ needs.create_github_release.outputs.release_url }}
             **Documentation**: ${{ needs.build_versioned_docs.outputs.docs_url }}
 
-            **Docker Images**:
-            - \`${{ env.DOCKER_REGISTRY }}/${{ github.repository }}-backend:${{ needs.validate_release.outputs.version }}\`
-            - \`${{ env.DOCKER_REGISTRY }}/${{ github.repository }}-frontend:${{ needs.validate_release.outputs.version }}\`
+            **Docker Image**:
+            \`\`\`bash
+            docker pull ${{ env.DOCKER_REGISTRY }}/${{ github.repository }}:${{ needs.validate_release.outputs.version }}
+            \`\`\`
 
             The release is now available for download and deployment.`;
 


### PR DESCRIPTION
## Summary

Consolidates CD and Release workflows to use the all-in-one Docker image (matching what CI tests) and adds explicit GitHub Actions permissions to all workflows for improved security and reliability.

## Changes

### 1. CD Workflow Consolidation
- **Replaced** separate `deploy_backend` and `deploy_frontend` jobs with single `deploy_application` job
- **Docker build** now targets `development` stage (all-in-one image with backend + frontend)
- **Image tags**: `ghcr.io/repo/partshub:VERSION` and `ghcr.io/repo/partshub:latest`
- **Updated** all dependent jobs (`notify_deployment`, `rollback_on_failure`)

### 2. Release Workflow Consolidation  
- **Renamed** `build_docker_images` to `build_docker_image` (singular)
- **Docker build** targets `development` stage (all-in-one image)
- **Updated** release notes to show single Docker image with Quick Start instructions
- **Updated** GitHub release creation and notifications

### 3. Explicit Permissions Added
Added explicit `permissions:` blocks to all three workflows:

**CI Workflow:**
- `contents: read` - Repository checkout
- `actions: write` - Dependency caching

**CD Workflow:**
- `contents: write` - GitHub Pages deployment
- `packages: write` - Push to GHCR
- `issues: write` - Deployment tracking
- `checks: read` - CI status checks
- `actions: write` - Docker layer caching
- `statuses: read` - Workflow status

**Release Workflow:**
- `contents: write` - Create releases, deploy docs
- `packages: write` - Push to GHCR
- `issues: write` - Release notifications
- `actions: write` - Docker layer caching

## Benefits

✅ **Consistency**: Deploy exactly what CI tests (the `development` target)
✅ **Simplicity**: One image instead of two separate images  
✅ **Performance**: Faster deployments with single build
✅ **Reliability**: Backend and frontend always deployed together
✅ **Security**: Explicit permissions follow principle of least privilege
✅ **Portability**: Workflows work regardless of repository settings

## Testing

- ✅ Verified no references to old job names remain
- ✅ Confirmed all workflow syntax is correct
- ✅ All permissions documented and justified

## Docker Image Usage

After this PR merges, the application can be run with:

```bash
docker pull ghcr.io/madeinoz67/partshub:latest
docker run -d -p 8000:8000 -p 3000:3000 ghcr.io/madeinoz67/partshub:latest

# Access:
# Backend API: http://localhost:8000
# Frontend: http://localhost:3000
```

## Related Issues

Addresses workflow consistency and security improvements for the PartsHub project.